### PR TITLE
Igualdad de arreglos funcionando

### DIFF
--- a/examples/array_echo.wd
+++ b/examples/array_echo.wd
@@ -1,0 +1,19 @@
+index_element: func(num, elem) =>
+    <- !(toStr num) . " -> " . elem
+endfn
+
+main: func() =>
+    array => []
+    while true =>
+        array => array . !input
+        !(printLine "Elementos")
+        
+        count => 0
+        while count < !(length array) =>
+            !(printLine !(index_element count (count @ array))) # Paréntesis están demás, pero es para claridad
+            count => count + 1
+        endwl
+    endwl
+endfn
+
+!main

--- a/examples/arrays.wd
+++ b/examples/arrays.wd
@@ -1,0 +1,43 @@
+function_1: func() =>
+    <- "Dentro de function_1"
+endfn
+
+function_2: func() =>
+    <- "Dentro de function_2 :)"
+endfn
+
+add: func(x, y) =>
+    <- x + y
+endfn
+
+string_var => "hola"
+array => [
+    10.9999998,
+    46,
+    "chao",
+    string_var,
+    2 + 4,
+    !function_1,
+    function_2,
+    add 
+]
+
+array => array . [1, 2, 3]
+array => array . "Hola de nuevo"
+
+!(printLine 3 @ array)
+!(printLine 4 @ array)
+!(printLine 5 @ array)
+
+func_name => 6 @ array
+!(printLine !func_name)
+
+!(printLine "Length: " . !(toStr !(length array)))
+
+func_arr => 7 @ array
+!(printLine !(func_arr 2 3))
+
+(4 @ array) => 666
+(0 @ array) => ":)"
+!(printLine array == [":)", 46, "chao", "hola", 666, "Dentro de function_1", function_2, add, [1, 2, 3], "Hola de nuevo"])
+!(printLine "The array is: " . !(toStr array))

--- a/examples/function.wd
+++ b/examples/function.wd
@@ -16,11 +16,11 @@ main: func() =>
     count => 0
     while count < 20 =>
         if count % 2 == 0 =>
-            !(print "Is even. Adding 5:")
+            !(print !(toStr count ) . " is even. Adding 5:")
             !(print " ")
             !(printLine !(add_5 count))
         else =>
-            !(print "Is odd.  Adding 8:")
+            !(print !(toStr count) . " is odd.  Adding 8:")
             !(print " ")
             !(printLine !(add_8 count))
         endif

--- a/examples/test.wd
+++ b/examples/test.wd
@@ -4,18 +4,23 @@ endfn
 
 # Pseudo range function
 range: func(start, end, step) =>
-    arr => [..end] # Array of length "end"
+    arr => []
     i => start
     while i < end =>
-        arr[i] => i * step
-        i +> 1
+        (i @ arr) => i * step
+        i => i + 1
     endwl
     <- arr
 endfn
 
 main: func() =>
-    for elem in !(range 0 !(add !input 1) 2) =>
-        !print !(add elem !input)
-    endfr
+    count => 0
+    range => !(range 0 !(add !(toNum !input) 1) 2)
+    !(printLine range)
+    while count < !(length range) =>
+        !(printLine !(add count @ range !(toNum !input)))
+        count => count + 1
+    endwl
 endfn
 
+!main

--- a/src/exec/builtin.rb
+++ b/src/exec/builtin.rb
@@ -19,6 +19,8 @@ end
 builtin_length = Proc.new do |str|
   if str.is_a?(WaidString)
     next WaidInteger.new(str.Value.length)
+  elsif str.is_a?(WaidArray)
+    next WaidInteger.new(str.Values.length)
   end
   next WaidNull.new
 end

--- a/src/exec/enviroment.rb
+++ b/src/exec/enviroment.rb
@@ -19,6 +19,11 @@ class Enviroment
     obj
   end 
 
+  def set_array_obj(id, index, value)
+    @Objects[id].Values[index] = value
+    value
+  end
+
   def set_func(name, func)
     @Functions[name] = func
     func

--- a/src/exec/eval.rb
+++ b/src/exec/eval.rb
@@ -17,6 +17,9 @@ def eval_node(node, env)
     value = eval_node(node.Value, env)
     env.set_ob(node.Identifier.Value, value)
 
+  when ArrayIndexDeclarationStatement
+    return evalArrayIndexDeclaration(node, env)
+
   when IfStatement
     return evalIfStatement(node, env)
 
@@ -57,6 +60,10 @@ def eval_node(node, env)
   when StringLiteral
     return WaidString.new(node.Value)
 
+  when ArrayLiteral
+    exprs = evalExpressions(node.Values, env)
+    return WaidArray.new(exprs)
+
   when NullLiteral
     return WaidNull.new
 
@@ -68,7 +75,7 @@ def eval_node(node, env)
     expr_l = eval_node(node.Left, env)
     # Acá debería revisar errores
     expr_r = eval_node(node.Right, env)
-    return evalBinaryOperatorExpression(node.Operator, expr_l, expr_r)
+    return evalBinaryOperatorExpression(node.Operator, expr_l, expr_r, env)
 
   when Identifier
     return evalIdentifier(node, env)
@@ -106,6 +113,21 @@ def boolToWaidBoolean(val)
   FalseValue
 end
 
+def evalArrayIndexDeclaration(node, env)
+  index = eval_node(node.IndexExpression, env)
+  if not index.is_a?(WaidInteger)
+    puts "Error: Array index must be an Integer, not of type #{index.type}"
+    exit()
+  elsif index.Value < 0
+    puts "Error: index #{index.Value} too small for array; minimum: 0"
+    exit()
+  end
+
+  eval_node(node.ArrayIdentifier, env) # Esto es para ver si existe el identificador
+  value = eval_node(node.Value, env)
+  env.set_array_obj(node.ArrayIdentifier.Value, index.Value, value)
+end
+
 def evalUnaryOperatorExpression(operator, expr)
   case operator.kind
   when TokenKind::OP_MINUS
@@ -128,17 +150,47 @@ def evalMinusOperatorExpression(expr)
   end
 end
 
-def evalBinaryOperatorExpression(operator, left, right)
+def evalBinaryOperatorExpression(operator, left, right, env)
   if left.is_a?(WaidInteger) and right.is_a?(WaidInteger)
     return evalIntegerBinaryOperatorexpression(operator, left, right)
   elsif left.is_a?(WaidFloat) or right.is_a?(WaidFloat)
     return evalFloatBinaryOperatorexpression(operator, left, right)
   elsif left.is_a?(WaidBoolean) and right.is_a?(WaidBoolean)
     return evalBooleanBinaryOperation(operator, left, right)
-  elsif left.is_a?(WaidString) and right.is_a?(WaidString)
+  elsif left.is_a?(WaidString) and right.is_a?(WaidString) and operator.kind == TokenKind::OP_DOT # TODO: Hacer evalStringBinaryOperation
     return WaidString.new(left.Value + right.Value)
+  elsif left.is_a?(WaidString) and right.is_a?(WaidString) and operator.kind == TokenKind::OP_EQUAL
+    return boolToWaidBoolean(left.Value == right.Value)
+  elsif left.is_a?(WaidArray) and right.is_a?(WaidArray) and operator.kind == TokenKind::OP_PLUS
+    return right.Values + left.Values
+  elsif left.is_a?(WaidInteger) and right.is_a?(WaidArray) and operator.kind == TokenKind::OP_AT
+    return right.Values[left.Value]
+  elsif left.is_a?(WaidFunction) and right.is_a?(WaidFunction) and operator.kind == TokenKind::OP_EQUAL
+    return boolToWaidBoolean(left == right)
   elsif left.is_a?(WaidNull) and right.is_a?(WaidNull) and operator.kind == TokenKind::OP_EQUAL
     return WaidBoolean.new(true)
+  elsif left.is_a?(WaidArray) and right.is_a?(WaidArray) and operator.kind == TokenKind::OP_DOT
+    left.Values.push(right.Values)
+    return left
+  elsif left.is_a?(WaidArray) and right.is_a?(WaidArray) and operator.kind == TokenKind::OP_EQUAL
+    val = true
+    if left.Values.length != right.Values.length
+      val = false
+    else
+      left.Values.zip(right.Values).each do |l, r|
+        puts "l: #{l.class}, r: #{r}"
+        if l.class != r.class
+          val = false
+          break
+        else
+          val = evalBinaryOperatorExpression(operator, l, r, env)
+        end
+      end
+    end
+    return boolToWaidBoolean(val)
+  elsif left.is_a?(WaidArray) and operator.kind == TokenKind::OP_DOT
+    left.Values.push(right)
+    return left
   else
     puts "Error: Type mismatch. Can not operate #{left.type} #{operator} #{right.type}"
     exit()
@@ -251,6 +303,9 @@ end
 
 def evalIdentifier(node, env)
   value = env.get(node.Value)
+  if not value.is_a?(WaidFunction)
+    puts "#{node.Value} -> #{value.Values[1].class}"
+  end
   if value
     return value
   end

--- a/src/exec/object.rb
+++ b/src/exec/object.rb
@@ -110,6 +110,33 @@ class WaidBoolean < WaidObject
   end
 end
 
+class WaidArray < WaidObject
+  attr_accessor :Values
+  def initialize(val=Array.new)
+    @Values = val
+  end
+
+  def type
+    "Array"
+  end
+
+  def inspect
+    str = "["
+    @Values.each_with_index do |val, index|
+      if val.is_a?(WaidString)
+        str += '"' + val.inspect + '"'
+      else
+        str += val.inspect
+      end
+      if index != @Values.length - 1
+        str += ", "
+      end
+    end
+    str += "]"
+    str
+  end
+end
+
 class WaidNull < WaidObject
   attr_accessor :Value
   def initialize

--- a/src/parser/ast.rb
+++ b/src/parser/ast.rb
@@ -79,6 +79,32 @@ class VarDeclarationStatement
   end
 end
 
+class ArrayIndexDeclarationStatement
+  attr_accessor :IndexExpression
+  attr_accessor :Value
+  attr_accessor :ArrayIdentifier
+  def initialize(ind=nil, name=nil, val=nil)
+    @IndexExpression = ind
+    @ArrayIdentifier = name
+    @Value = val
+  end
+
+  def print_tree(indent, last)
+    print indent
+    indent += indentation(last)
+
+    puts "ArrayIndexDeclaration"
+    puts indent + $AST_MIDDLE + "IndexExpression"
+    @IndexExpression.print_tree(indent + $AST_LINE, true)
+
+    puts indent + $AST_MIDDLE + "ArrayIdentifier"
+    @ArrayIdentifier.print_tree(indent + $AST_LINE, true)
+
+    puts indent + $AST_LAST + "Value"
+    @Value.print_tree(indent + $AST_SPACE, true)
+  end
+end
+
 class FuncDeclarationStatement
   attr_accessor :Identifier
   attr_accessor :Parameters
@@ -264,6 +290,27 @@ class IntLiteral
 
     puts "IntLiteral"
     puts indent + $AST_LAST + @Value.to_s
+  end
+end
+
+class ArrayLiteral
+  attr_accessor :Values
+  def initialize
+    @Values = Array.new
+  end
+
+  def print_tree(indent, last)
+    print indent
+    indent += indentation(last)
+
+    puts "ArrayLiteral"
+    if @Values.empty?
+      puts indent + $AST_LAST + "Empty"
+      return
+    end
+    @Values.each_with_index do |expr, index|
+      expr.print_tree(indent + $AST_SPACE, index == @Values.length - 1)
+    end
   end
 end
 

--- a/src/tokenizer/token.rb
+++ b/src/tokenizer/token.rb
@@ -47,14 +47,15 @@ module TokenKind
   OP_GREATER_EQUAL     = 0x27
   OP_RETURN            = 0x28
   OP_EXCLAMATION       = 0x29
+  OP_AT                = 0x2A
 
-  OP_COMMA             = 0x2A
-  OP_COLON             = 0x2B
-  OP_DOT               = 0x2C
-  OP_OPEN_PARENTHESIS  = 0x2D
-  OP_CLOSE_PARENTHESIS = 0x2E
-  OP_OPEN_BRACKETS     = 0x2F
-  OP_CLOSE_BRACKETS    = 0x30
+  OP_COMMA             = 0x2B
+  OP_COLON             = 0x2C
+  OP_DOT               = 0x2D
+  OP_OPEN_PARENTHESIS  = 0x2E
+  OP_CLOSE_PARENTHESIS = 0x2F
+  OP_OPEN_BRACKETS     = 0x30
+  OP_CLOSE_BRACKETS    = 0x31
 end
 
 def token_string(tok)
@@ -144,9 +145,8 @@ def token_string(tok)
         "<-"
       when TokenKind::OP_EXCLAMATION
         "!"
-        #when TokenKind::OP_AT
-        #  "@"
-
+      when TokenKind::OP_AT
+        "@"
       when TokenKind::OP_COMMA
         ","
       when TokenKind::OP_COLON

--- a/src/tokenizer/tokenizer.rb
+++ b/src/tokenizer/tokenizer.rb
@@ -186,6 +186,8 @@ class Tokenizer
           elsif @peek_char == '='
             pushChar
             TokenKind::OP_EQUAL
+          else
+            return
           end
         when '<'
           if @peek_char == "-"
@@ -206,6 +208,8 @@ class Tokenizer
           end
         when '!'
           TokenKind::OP_EXCLAMATION
+        when '@'
+          TokenKind::OP_AT
         when ','
           TokenKind::OP_COMMA
         when '.'


### PR DESCRIPTION
También está funcionando la asignación de valores específicos de un arreglo. Si bien yo quería una sintaxis así:
`index @ array => expression`
debido al parser que estoy usando, y ya que no puedo tener recursión hacia la izquierda, tuve que dejar la sintaxis así:
`(index @ array) => expression`

No es lo que buscaba, pero no queda tan mal y funciona